### PR TITLE
Fix typo in types filename.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "build": "npx quack build",
         "types": "npx tsc -p . --declaration --allowJs --emitDeclarationOnly --outDir types"
     },
-    "types": "types/Pict.Template.d.ts",
+    "types": "types/Pict-Template.d.ts",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/stevenvelozo/pict-view.git"


### PR DESCRIPTION
Seems like I goofed on this, filename has a `-` but `package.json` has a `.`.